### PR TITLE
scripts: add template-based generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,26 +11,38 @@ jobs:
     runs-on: ubuntu-latest
     # This only works with the "matrix" strategy
     #fail-fast: false
+
+    env:
+      PYTHONPATH: ${{ github.workspace }}/.scripts
+
     steps:
 
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup Environment
+    - name: Setup Python Environment
+      run: |
+        sudo apt install -y python3-pytest
+
+    - name: Test Python
+      run: |
+        pytest-3 .scripts/*_test.py
+
+    - name: Setup C++ CEnvironment
       run: |
         sudo apt-get update
         sudo apt install -y cmake clang clang-tidy gcovr
         sudo sh .scripts/build-and-install-libgtest-libraries.sh
 
-    - name: Build
+    - name: Build C++
       run: |
         make -j`nproc --all`
 
-    - name: Test
+    - name: Test C++
       run: |
         make check
 
-    - name: Coverage
+    - name: Get C++ Test Coverage
       run: |
         make gcov
         bash <(curl -s https://codecov.io/bash)

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.gcov
 .*project
 .settings/
+__pycache__/

--- a/.scripts/new-problem
+++ b/.scripts/new-problem
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import sys
+
+import problem
+
+if __name__ == '__main__':
+    problem.new_problem()
+    sys.exit(0)

--- a/.scripts/problem.py
+++ b/.scripts/problem.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021, Christopher Friedt
+#
+# SPDX-License-Identifier: MIT
+
+from datetime import datetime
+import enum
+import os
+import re
+import sys
+import types
+
+
+LEETCODE_URL_BASE = 'https://leetcode.com/problems'
+GITHUB_URL_BASE = 'https://github.com/cfriedt/leetcode'
+SPDX_LICENSE_IDENTIFIER = 'MIT'
+COPYRIGHT_HOLDER = 'Christopher Friedt'
+
+NAME_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]+$')
+
+
+class Difficulty(enum.IntEnum):
+    INVALID = 0
+    EASY = 1
+    MEDIUM = 2
+    HARD = 3
+
+
+class Problem(object):
+
+    @staticmethod
+    def to_camel(name):
+        # converts e.g. 3sum to 3Sum, n-queens-ii to NQueensIi
+        prev = '-'
+        camel = ''
+
+        for i in range(len(name)):
+            c = name[i]
+            if c != '-':
+                if (prev == '-' or prev.isnumeric() or i == 0) and c.isalpha():
+                    c = c.upper()
+                camel += c
+            prev = c
+
+        return camel
+
+    def is_name_valid(name):
+        return re.match(NAME_RE, name)
+
+    @staticmethod
+    def default_args():
+        args = types.SimpleNamespace()
+        args.verbose = False
+        args.name = ''
+        args.issue = -1
+        args.problem_template = ''
+        args.difficulty = Difficulty.INVALID
+        args.time = -1  # ms
+        args.time_rank = -1  # %
+        args.time_complexity = ''  # O(...)
+        args.space = -1  # MB
+        args.space_rank = -1  # %
+        args.space_complexity = ''  # O(...)
+        return args
+
+    def D(self, msg):
+        if self._verbose:
+            print(msg)
+
+    def __init__(self, args):
+        self._verbose = args.verbose
+        if args.verbose is not True and args.verbose is not False:
+            raise ValueError('invalid verbosity "{}"'.format(args.verbose))
+
+        self._name = args.name
+        if not Problem.is_name_valid(args.name):
+            raise ValueError('invalid name "{}"'.format(args.name))
+
+        self._camel = Problem.to_camel(self._name)
+
+        # leetcode attributes
+        self._url = '{}/{}'.format(LEETCODE_URL_BASE, args.name)
+
+        # github attributes
+        self._issue = args.issue
+
+        # problem attributes
+        # self._leetcode_number = -1
+        self._problem_template = args.problem_template
+
+        self._difficulty = args.difficulty
+
+        self._time = args.time  # ms
+        self._time_rank = args.time_rank  # %
+        self._time_complexity = args.time_complexity  # O(...)
+
+        self._space = args.space  # MB
+        self._space_rank = args.space_rank  # %
+        self._space_complexity = args.space_complexity  # O(...)
+
+    # would be ideal to provie an init_from_url() method
+    # but leetcode's page is mostly populated via async JS
+    # which makes scraping (without heavyweight frameworks)
+    # kind of difficult
+    # def init_from_url(self):
+    #    pass
+
+    def create_impl_and_test(self):
+        impl_cpp = self._name + '.cpp'
+        test_cpp = self._name + '-test.cpp'
+
+        year = datetime.today().year
+        try:
+            if os.path.exists(impl_cpp):
+                raise ValueError(
+                    'file {} already exists'.format(impl_cpp))
+
+            if os.path.exists(test_cpp):
+                raise ValueError('file {} already exists'.format(test_cpp))
+
+            # create the implementation
+            with open(impl_cpp, 'x') as f:
+                self.D('opened {} as {}'.format(impl_cpp, f))
+
+                # write the copyright and license info in SPDX format
+                f.write('/*\n')
+                f.write(' * Copyright (c) {}, {}\n'.format(year, COPYRIGHT_HOLDER))
+                f.write(' *\n')
+                f.write(
+                    ' * SPDX-License-Identifier: {}\n'.format(SPDX_LICENSE_IDENTIFIER))
+                f.write(' */\n')
+                f.write('\n')
+
+                # boilerplate C++
+                f.write('#include <vector>\n'.format(self._name))
+                f.write('\n')
+                f.write('using namespace std;\n'.format(self._url))
+                f.write('\n')
+
+                # write problem metadata
+                f.write('// name: {}\n'.format(self._name))
+                f.write('// url: {}\n'.format(self._url))
+                f.write('// difficulty: {}\n'.format(self._difficulty))
+                f.write('\n')
+
+                # write the problem template
+                f.write(self._problem_template + '\n')
+
+            self.D('created file {}'.format(impl_cpp))
+
+            # create the test
+            with open(test_cpp, 'x') as f:
+                self.D('opened {} as {}'.format(test_cpp, f))
+
+                # write the copyright and license info in SPDX format
+                f.write('/*\n')
+                f.write(' * Copyright (c) {}, {}\n'.format(year, COPYRIGHT_HOLDER))
+                f.write(' *\n')
+                f.write(
+                    ' * SPDX-License-Identifier: {}\n'.format(SPDX_LICENSE_IDENTIFIER))
+                f.write(' */\n')
+                f.write('\n')
+
+                # include gtest
+                f.write('#include <gtest/gtest.h>\n'.format(self._name))
+                f.write('\n')
+
+                # include impl
+                f.write('#include "{}.cpp"\n'.format(self._name))
+                f.write('\n')
+
+                # boilerplate C++
+                f.write('using namespace std;\n'.format(self._url))
+                f.write('\n')
+
+                # trivial test
+                f.write('TEST({}, empty) {{\n'.format(self._camel))
+                f.write('}\n')
+                f.write('\n')
+
+            self.D('created file {}'.format(test_cpp))
+
+        except Exception as e:
+            try:
+                os.remove(impl_cpp)
+                os.remove(test_cpp)
+            except:
+                pass
+
+            raise
+
+def new_problem():
+    args = Problem.default_args()
+
+    print('Enter the problem name: ', end='', flush=True)
+    for line in sys.stdin:
+        args.name = line.rstrip()
+        break
+
+    print('Enter the GitHub issue number: ', end='', flush=True)
+    for line in sys.stdin:
+        args.issue = int(line.rstrip())
+        break
+
+    print('Enter the difficulty level (1=easy, 2=medium, 3=hard): ',
+          end='', flush=True)
+    for line in sys.stdin:
+        args.difficulty = int(line.rstrip())
+        if 1 <= args.difficulty and args.difficulty <= 3:
+            break
+
+    print('Enter the Solution template:')
+    for line in sys.stdin:
+        if line == '\n':
+            break
+        args.problem_template += line
+
+    p = Problem(args)
+    p.create_impl_and_test()
+
+    return p

--- a/.scripts/problem_test.py
+++ b/.scripts/problem_test.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021, Christopher Friedt
+#
+# SPDX-License-Identifier: MIT
+
+import io
+import os
+import requests
+import types
+
+import pytest
+
+import problem
+from problem import Problem
+from problem import Difficulty
+
+
+def test_init_happy_path():
+    args = Problem.default_args()
+    args.name = '3sum'
+    p = Problem(args)
+
+    # misc attributes
+    assert(p._verbose == False)
+
+    # leetcode attributes
+    assert(p._name == args.name)
+    assert(p._url == problem.LEETCODE_URL_BASE + '/' + args.name)
+
+    # github attributes
+    assert(p._issue == -1)
+
+    # problem attributes
+    #assert(p._leetcode_number == -1)
+    assert(p._problem_template == '')
+
+    assert(p._difficulty == Difficulty.INVALID)
+
+    assert(p._time == -1)
+    assert(p._time_rank == -1)
+    assert(p._time_complexity == '')
+
+    assert(p._space == -1)
+    assert(p._space_rank == -1)
+    assert(p._space_complexity == '')
+
+
+def test_missing_args():
+    # no attributes
+    with pytest.raises(AttributeError):
+        args = types.SimpleNamespace()
+        p = Problem(args)
+
+    # missing name attribute
+    with pytest.raises(AttributeError):
+        args = types.SimpleNamespace()
+        args.verbose = False
+        p = Problem(args)
+
+    # missing verbose attribute
+    with pytest.raises(AttributeError):
+        args = types.SimpleNamespace()
+        args.name = 'abc'
+        p = Problem(args)
+
+
+def test_init_invalid_verbose():
+    invalid = [None, 42, 'Foo']
+    for i in invalid:
+        with pytest.raises(ValueError, match=r'invalid verbosity ".*"'):
+            args = Problem.default_args()
+            args.name = 'abc'
+            args.verbose = i
+            p = Problem(args)
+
+
+def test_init_invalid_name():
+    invalid = ['', 'a', 'a-', '-a', '!', 'ab!c']
+    for i in invalid:
+        with pytest.raises(ValueError, match=r'invalid name ".*"'):
+            args = Problem.default_args()
+            args.name = i
+            p = Problem(args)
+
+
+def test_create_problem(monkeypatch):
+
+    solution = \
+        '''class Solution {
+public:
+    int fooBar(int z) {
+        
+    }
+};
+
+'''
+
+    my_stdin = 'TEST-foo-bar\n42\n3\n' + solution
+    my_stdout = ''
+
+    monkeypatch.setattr('sys.stdin', io.StringIO(my_stdin))
+    p = problem.new_problem()
+
+    assert(p._name == 'TEST-foo-bar')
+    assert(p._camel == 'TESTFooBar')
+    assert(p._issue == 42)
+    assert(p._difficulty == Difficulty.HARD)
+    assert(p._problem_template + '\n' == solution)
+
+    io_fail = False
+
+    impl_cpp = p._name + '.cpp'
+    test_cpp = p._name + '-test.cpp'
+
+    if not os.path.exists(impl_cpp):
+        io_fail = True
+
+    if not os.path.exists(test_cpp):
+        io_fail = True
+
+    if io_fail:
+        try:
+            os.remove(impl_cpp)
+            os.remove(test_cpp)
+        except:
+            pass
+
+    assert(os.path.exists(impl_cpp))
+    assert(os.path.exists(test_cpp))
+
+    os.remove(impl_cpp)
+    os.remove(test_cpp)
+
+    # expected = ''
+    # expected += 'Enter the problem name: '
+    # expected += 'Enter the GitHub issue number: '
+    # expected += 'Enter the difficulty level (1=easy, 2=medium, 3=hard): '
+    # expected += 'Enter the Solution template: '
+    ## this needs using capsys as a function, but it's already monkeypatch
+    # my_stdout = capsys.readouterr()
+    # assert(my_stdout == expected)
+
+    assert(p._time == -1)
+    assert(p._time_rank == -1)
+    assert(p._time_complexity == '')
+
+    assert(p._space == -1)
+    assert(p._space_rank == -1)
+    assert(p._space_complexity == '')


### PR DESCRIPTION
This change adds a python script to assist in creating
the impl.cpp and impl-test.cpp files using templates.

Ideally, we could scrape some very basic information
from leetcode.com, but that seems to be more beyond
the scope of a simple static content parser.

Here we have added a tool that just reads input
from stdin.

E.g.
$ .scripts/new-problem
Enter the problem name: foobar
Enter the GitHub issue number: 42
Enter the difficulty level (1=easy, 2=medium, 3=hard): 3
Enter the Solution template:
\#define FOOBAR foo(bar)

Two files would be created as a result.
foobar.cpp
foobar-test.cpp

Fixes #268