### PR TITLE
scripts: new-problem: create a branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
 
     env:
       PYTHONPATH: ${{ github.workspace }}/.scripts
+      # ideally there would be a simple way to append / prepend to the path outside of jobs, but no
+      PATH: /home/runner/.local/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/opt/pipx_bin:/usr/share/rust/.cargo/bin:/home/runner/.config/composer/vendor/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
 
     steps:
 
@@ -22,15 +24,24 @@ jobs:
 
     - name: Setup Python Environment
       run: |
-        sudo apt install -y python3-pytest
+        pip3 install --upgrade pip
+        pip3 install -r .scripts/requirements.txt
 
     - name: Test Python
       run: |
-        pytest-3 .scripts/*_test.py
+        # Both problem.py and problem_test.py assume that the 'master' branch is available
+        # but GitHub Actions only check out 1 ref (e.g. 'pull/289/merge', a GitHub-managed tag).
+        # Here we create the master branch if it does not already exist.
+        if [ "$(git branch --list master)" == "" ]; then
+            REF="$(git rev-parse HEAD)"
+            git fetch origin
+            git checkout -b master origin/master
+            git checkout ${REF}
+        fi
+        pytest .scripts/*_test.py
 
     - name: Setup C++ CEnvironment
       run: |
-        sudo apt-get update
         sudo apt install -y cmake clang clang-tidy gcovr
         sudo sh .scripts/build-and-install-libgtest-libraries.sh
 

--- a/.scripts/problem.py
+++ b/.scripts/problem.py
@@ -6,6 +6,7 @@
 
 from datetime import datetime
 import enum
+from git import Repo
 import os
 import re
 import sys
@@ -84,6 +85,7 @@ class Problem(object):
 
         # github attributes
         self._issue = args.issue
+        self._branch = 'issue/{}/{}'.format(args.issue, args.name)
 
         # problem attributes
         # self._leetcode_number = -1
@@ -192,6 +194,26 @@ class Problem(object):
 
             raise
 
+    def checkout_branch(self, create=True):
+        repo = Repo(os.getcwd())
+        git = repo.git
+
+        try:
+            # stash any uncommitted changes
+            git.add('*')
+            git.stash()
+        except:
+            pass
+
+        git.checkout('master')
+        git.fetch('-p')
+        git.pull()
+
+        if create:
+            git.checkout('-b', self._branch)
+        else:
+            git.checkout(self._branch)
+
 def new_problem():
     args = Problem.default_args()
 
@@ -219,6 +241,7 @@ def new_problem():
         args.problem_template += line
 
     p = Problem(args)
+    p.checkout_branch()
     p.create_impl_and_test()
 
     return p

--- a/.scripts/requirements.txt
+++ b/.scripts/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+gitpython
+


### PR DESCRIPTION
This change modifies the 'new-problem' script to also create a new branch.
- stash any uncommitted changes
- switch to the master branch
- fetch and pull
- checkout a new branch using the template 'issue/{issue_number}/{problem_name}'

Fixes #288